### PR TITLE
Request: Add a .primary class for the macOS 9 primary button style.

### DIFF
--- a/themes/macos9/_buttons.scss
+++ b/themes/macos9/_buttons.scss
@@ -32,3 +32,22 @@
   }
 }
 
+#{util.$buttons} {
+  &.primary {
+    position: relative;
+    z-index: 1;
+    box-shadow: inset 1px 1px 0 #DDDDDD, inset 2px 2px 0 #fff, inset -1px -1px 1px #555, -1px -1px 2px #00000057, 2px 2px 2px #ffffff8a;
+
+    &::before {
+      content: " ";
+      width: calc(100% + 8px);
+      height: calc(100% + 8px);
+      left: -4px;
+      top: -4px;
+      position: absolute;
+      border-radius: 6px;
+      box-sizing: border-box;
+      z-index: -1;
+      box-shadow: 0px 0px 0px 1px black, inset 0px 0px 2px white, inset -2px -2px 3px #545454;  }
+    }
+}


### PR DESCRIPTION
MacOS 8/9 has a default/primary button style where the default option has an extra 3d border around it

![macOS9 Dialog](https://github.com/user-attachments/assets/c347d37a-4482-4ed1-8d05-de1b49dc4ad0)

Request to add this as the primary class, appearing as shown:

![macOS9 Preview](https://github.com/user-attachments/assets/ac9320e6-91ed-418a-a350-16fb24a304c5)
